### PR TITLE
Force ssh-add to ask for password in the terminal

### DIFF
--- a/vkl
+++ b/vkl
@@ -27,6 +27,8 @@ if [[ `lpass status` != *$USER* ]]; then
   lpass login $USER
 fi
 
+unset DISPLAY # forces ssh-add to ask for the password in the terminal
+
 /usr/bin/ssh-add -D
 lpass show --notes 'Productivity Tools/id_rsa' | /usr/bin/ssh-add -t ${HOURS}H -
 


### PR DESCRIPTION
`ssh-add` uses the DISPLAY environment variable to determine if the user is running in a GUI or not.  If this environment variable is set then `ssh-add` tries to be friendly and launch an external GUI program so the user can enter their password.  Since `vkl` users always use `vkl` in a terminal then this behaviour is broken.  By unsetting this environment variable then we can force `vkl` to ask for the password directly in the terminal.