### PR TITLE
Only use the first field in .git-config to match the user initials

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,3 @@ Example:
 
 ## Acknowledgements
 Hat tip to [Paul Nikonowicz](https://github.com/pnikonowicz) and [Andreas Voellmer](https://github.com/sigilite) who passed along earlier versions of this script.
-
-## FAQ
-
-* ssh_askpass: exec(/usr/X11R6/bin/ssh-askpass): No such file or directory
-```
-brew install ssh-askpass
-sudo brew services start theseal/ssh-askpass/ssh-askpass
-pushd /usr/X11r6/bin
-sudo ln -s /usr/local/bin/ssh-askpass ssh-askpass
-popd
-```

--- a/vkl
+++ b/vkl
@@ -14,7 +14,7 @@ if [[ -z $HOURS ]]; then
   echo "Hours: $HOURS"
 fi
 
-USER_PREFIX=$(grep $USER_INITIALS ~/.git-authors | awk -F '; ' '{print $2}')
+USER_PREFIX=$(grep "^\s*${USER_INITIALS}:" ~/.git-authors | awk -F '; ' '{print $2}')
 if [[ $USER_PREFIX == "" ]]; then
   USER=$USER_INITIALS
   echo 'Unknown initial. Using as email'


### PR DESCRIPTION
I tried `vkl rs` and I was matching someone different so I restricted the `grep` to only match the first column in the `git-authors` file.  Also, I removed the section in the FAQ since it was covered by my previous pull request.